### PR TITLE
fix: graph is deprecated on Docker 17.05

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -37,7 +37,7 @@
   copy:
     content: |-
       {
-        "graph": "/data/var/lib/docker"
+        "data-root": "/data/var/lib/docker"
       }
     dest: /etc/docker/daemon.json
     mode: "0644"


### PR DESCRIPTION
`data-root` is the new parameter

Deprecation notes: https://docs.docker.com/engine/deprecated/#-g-and---graph-flags-on-dockerd