### PR TITLE
fix: Delete docker tar file after install

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -41,3 +41,8 @@
       }
     dest: /etc/docker/daemon.json
     mode: "0644"
+
+- name: Delete temp Docker tar file
+  file:
+    path: /tmp/docker.tgz
+    state: absent


### PR DESCRIPTION
This is for the tmp_less_than_200mb_linux greenbay test.
