### PR TITLE
fix: Delete the old docker binary when updating

### DIFF
--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -18,8 +18,7 @@
 
 - name: Move docker binaries to bin
   shell: mv /tmp/docker/* /usr/bin/
-  args:
-    creates: /usr/bin/docker
+  changed_when: false
 
 - name: Create docker group
   group:

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -1,4 +1,9 @@
 ---
+- name: Delete old docker binary
+  file:
+    path: /usr/bin/docker
+    state: absent
+
 - name: Download docker tar file
   get_url:
     url: "{{ docker_download_url }}"


### PR DESCRIPTION
The old binary will be deleted if its version is different from the
desired binary's version.
